### PR TITLE
Component type support for 'icon' prop and bugfix and update Readme

### DIFF
--- a/ItemCell.js
+++ b/ItemCell.js
@@ -41,7 +41,14 @@ class ItemCell extends React.Component {
   }
 
   _renderIcon () {
-    if (this.props.icon) {
+    if (React.isValidElement(this.props.icon)) {
+      return (
+        <View style={styles.iconContainer}>
+          {this.props.icon}
+        </View>
+      )
+    }
+    else if (this.props.icon) {
       return (
         <View style={styles.iconContainer}>
           <Image
@@ -112,12 +119,12 @@ ItemCell.propTypes = {
   ...TouchableHighlight.propTypes,
   backgroundColor: PropTypes.string,
   subtitle: PropTypes.string,
-  children: PropTypes.string.isRequired,
   value: PropTypes.string,
   showDisclosureIndicator: PropTypes.bool,
   textStyle: Text.propTypes.style,
   chevronColor: PropTypes.string,
   icon: PropTypes.oneOfType([
+    PropTypes.element,
     PropTypes.number,
     PropTypes.shape({
       uri: PropTypes.string,

--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@ A React Native default iOS item cell. The cell grows with the inner text.
 
 ## Install
 
-RN>=0.18 is required for `1.4.x`. Install the package:
+RN>=0.18 is required for `1.4.x`.
 
+### 1. Install the package:
+
+#### option: yarn 
 ```bash
 $ yarn add react-native-item-cell
 ```
+
+#### option: npm
+```bash
+$ npm install react-native-item-cell --save
+```
+
+### 2. Install the dependence:
 
 Install ``FontAwesome`` from the awesome Joel Oblador's ``react-native-vector-icons``: https://github.com/oblador/react-native-vector-icons#installation
 
@@ -30,8 +40,7 @@ Install ``FontAwesome`` from the awesome Joel Oblador's ``react-native-vector-ic
 | Prop | Type | Description |
 |------|------|-------------|
 |``showDisclosureIndicator`` | ``bool`` | Shows a small arrow at the right side of the cell. |
-|``icon`` | ``{uri: string}`` object or ``require()`` | URI to render left icon with an URL for the image source or ``require`` for a local image source. |
-|``children`` | ``string`` | The inner text to render. |
+|``icon`` | React component or ``{uri: string}`` object or ``require()`` | React component or URI to render left icon with an URL for the image source or ``require`` for a local image source. |
 | `subtitle` | `string` | An optional subtitle to render below the `children`. |
 | `value` | `string` | An optional value to display instead of the disclosure indicator. |
 | `backgroundColor` | `string` | The color code of the cell background color. |


### PR DESCRIPTION
1. Support component/react element type of 'icon' prop.  Now we can use react-native-vector-icons or other image component like this: 
```javascript
<ItemCell
  icon={<Icon name="ios-person" size={30} color="#4F8EF7" />}
>
  text here
</ItemCell>
```
2. Remove children proptype check. "this.props.children" is a special prop of React： https://facebook.github.io/react/docs/jsx-in-depth.html#children-in-jsx , the children prop here won't work and will leads to an warning. 

3. update the doc

Tested on my local env, maybe need furthermore tests.